### PR TITLE
feat(ansible): add custom MOTD role with ASCII art banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+```
+ ███╗   ██╗███████╗██╗   ██╗████████╗██████╗  ██████╗ ███╗   ██╗
+ ████╗  ██║██╔════╝██║   ██║╚══██╔══╝██╔══██╗██╔═══██╗████╗  ██║
+ ██╔██╗ ██║█████╗  ██║   ██║   ██║   ██████╔╝██║   ██║██╔██╗ ██║
+ ██║╚██╗██║██╔══╝  ██║   ██║   ██║   ██╔══██╗██║   ██║██║╚██╗██║
+ ██║ ╚████║███████╗╚██████╔╝   ██║   ██║  ██║╚██████╔╝██║ ╚████║
+ ╚═╝  ╚═══╝╚══════╝ ╚═════╝    ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝
+```
+
 # 🚀 Neutron - Multi-Service Platform Automation
 
 ![Stars](https://img.shields.io/github/stars/xgueret/proxmox-vm-neutron?style=social) ![Last Commit](https://img.shields.io/github/last-commit/xgueret/proxmox-vm-neutron) ![Status](https://img.shields.io/badge/Status-Active-brightgreen)
@@ -79,6 +88,7 @@ pm_api_token_secret  = "your-token-secret"
 
 ### 🔑 Available Ansible Tags
 
+- `motd` - Deploy custom MOTD with ASCII art banner
 - `docker` - Install Docker and Docker Compose
 - `portainer-agent` - Deploy Portainer Agent
 
@@ -119,6 +129,7 @@ pre-commit install
 │   │   └── neutron/              # Group variables
 │   │       └── vault/            # Encrypted variables
 │   └── roles/                    # Ansible roles
+│       ├── motd/                 # Custom MOTD banner
 │       ├── docker/               # Docker installation
 │       └── portainer_agent/      # Portainer Agent
 ├── terraform/

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -19,6 +19,9 @@
         mode: '0770'
 
   roles:
+    - role: motd
+      tags:
+        - motd
     - role: docker
       tags:
         - docker

--- a/ansible/roles/motd/defaults/main.yml
+++ b/ansible/roles/motd/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Enable/disable default MOTD scripts
+motd_disable_default_motd: true

--- a/ansible/roles/motd/tasks/main.yml
+++ b/ansible/roles/motd/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Disable default MOTD scripts
+  ansible.builtin.file:
+    path: "{{ item }}"
+    mode: '0644'
+  loop:
+    - /etc/update-motd.d/10-help-text
+    - /etc/update-motd.d/50-motd-news
+    - /etc/update-motd.d/90-updates-available
+    - /etc/update-motd.d/91-release-upgrade
+    - /etc/update-motd.d/92-unattended-upgrades
+  failed_when: false
+  when: motd_disable_default_motd
+
+- name: Deploy custom MOTD
+  ansible.builtin.template:
+    src: motd.j2
+    dest: /etc/motd
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Remove custom dynamic MOTD script if exists
+  ansible.builtin.file:
+    path: /etc/update-motd.d/00-neutron
+    state: absent

--- a/ansible/roles/motd/templates/motd.j2
+++ b/ansible/roles/motd/templates/motd.j2
@@ -1,0 +1,27 @@
+
+{{ ansible_managed | comment }}
+
+ ███╗   ██╗███████╗██╗   ██╗████████╗██████╗  ██████╗ ███╗   ██╗
+ ████╗  ██║██╔════╝██║   ██║╚══██╔══╝██╔══██╗██╔═══██╗████╗  ██║
+ ██╔██╗ ██║█████╗  ██║   ██║   ██║   ██████╔╝██║   ██║██╔██╗ ██║
+ ██║╚██╗██║██╔══╝  ██║   ██║   ██║   ██╔══██╗██║   ██║██║╚██╗██║
+ ██║ ╚████║███████╗╚██████╔╝   ██║   ██║  ██║╚██████╔╝██║ ╚████║
+ ╚═╝  ╚═══╝╚══════╝ ╚═════╝    ╚═╝   ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Hostname:     {{ ansible_hostname }}
+  IP Address:   {{ ansible_default_ipv4.address | default('N/A') }}
+  OS:           {{ ansible_distribution }} {{ ansible_distribution_version }}
+  Kernel:       {{ ansible_kernel }}
+  Uptime:       {{ ansible_uptime_seconds | int // 86400 }}d {{ (ansible_uptime_seconds | int % 86400) // 3600 }}h {{ (ansible_uptime_seconds | int % 3600) // 60 }}m
+  CPU:          {{ ansible_processor_vcpus }} vCPU(s)
+  Memory:       {{ (ansible_memtotal_mb / 1024) | round(1) }} GB
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  Docker Host | Infrastructure as Code | Proxmox VM
+
+  ╭───────────────────────────────────────────────────────────╮
+  │  TiPunchLabs - Homelab Infrastructure                     │
+  │  https://github.com/tipunchlabs                           │
+  ╰───────────────────────────────────────────────────────────╯
+

--- a/ansible/roles/portainer_agent/tasks/main.yml
+++ b/ansible/roles/portainer_agent/tasks/main.yml
@@ -20,4 +20,6 @@
   community.docker.docker_compose_v2:
     project_src: /opt/portainer/agent
     state: present
+    recreate: auto
+    remove_orphans: true
   register: portainer_agent_deploy


### PR DESCRIPTION
- Create motd role with NEUTRON ASCII art banner
- Display system info (hostname, IP, OS, kernel, uptime, CPU, memory)
- Include TiPunchLabs branding
- Disable default Ubuntu MOTD scripts to avoid clutter
- Fix portainer_agent idempotency with recreate:auto and remove_orphans:true
- Update README with ASCII art and new motd tag documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure change (Terraform/Ansible modifications)

## Changes Made

- Change 1
- Change 2

## Testing

Describe the tests you ran to verify your changes:

- [ ] `terraform validate` passes
- [ ] `terraform fmt` applied
- [ ] `ansible-playbook --syntax-check` passes
- [ ] `pre-commit run --all-files` passes
- [ ] Tested on Proxmox environment (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation if needed
- [ ] All vault files are encrypted
- [ ] No credentials or secrets are exposed

## Related Issues

Fixes #(issue number)

## Screenshots (if applicable)

Add screenshots to help explain your changes.
